### PR TITLE
Fix question owner reassignment on question answer

### DIFF
--- a/client/src/store/reducers/questions.js
+++ b/client/src/store/reducers/questions.js
@@ -17,8 +17,13 @@ export const questions = (state = initialState, action) => {
       };
     // answer questions logic
     case ActionTypes.ANSWER_QUESTION_SUCCESS: {
-      const newQuestions = state.questions.map(q => q.id === action.payload.id ? action.payload : q);
-      return Object.assign({}, state, {questions: newQuestions});
+      const newQuestions = state.questions.map((q) => {
+        if (q.id === action.payload.id) {
+          return {...action.payload, owner: q.owner};
+        }
+        return q;
+      });
+      return {...state, questions: newQuestions};
     }
     case ActionTypes.CREATE_QUESTION_SUCCESS: {
       const newQuestions = [...state.questions, action.payload];


### PR DESCRIPTION
When answering a question, the questions owner value is replaced from an object to a primitive using only the owner.id value. 

(This is the same solution as used in the UPDATE_QUESTION_SUCCESS ActionType)
![image](https://user-images.githubusercontent.com/144069/38044485-da64ff34-32b1-11e8-9f09-60db88a088b1.png)
![image](https://user-images.githubusercontent.com/144069/38044603-2f63d064-32b2-11e8-85f3-dfb3a647be48.png)

